### PR TITLE
Self deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ocaml/opam:debian-ocaml-4.12 AS build
+RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && opam update
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 01c350d759f8d4e3202596371818e6d997fa5fe2 && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 2b4b9092c09d189e80d1fec1f48361839143ff7c && opam update
 COPY --chown=opam \
 	vendor/ocurrent/current_ansi.opam \
 	vendor/ocurrent/current_docker.opam \
@@ -26,7 +27,7 @@ COPY --chown=opam mirage-ci.opam /src/
 RUN opam install -y --deps-only .
 ADD --chown=opam . .
 RUN --mount=type=cache,target=./_build/,uid=1000,gid=1000 opam config exec -- dune build ./_build/install/default/bin/mirage-ci ./_build/install/default/bin/mirage-ci-solver && cp ./_build/install/default/bin/mirage-ci ./_build/install/default/bin/mirage-ci-solver .
-FROM debian:10
+FROM debian:11
 RUN apt-get update && apt-get install libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase gzip bzip2 xz-utils unzip tar -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
@@ -35,4 +36,5 @@ RUN git config --global user.name "mirage" && git config --global user.email "ci
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/mirage-ci"]
 ENV OCAMLRUNPARAM=a=2
+ENV DOCKER_BUILDKIT=1
 COPY --from=build /src/mirage-ci /src/mirage-ci-solver /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,37 @@ dune exec -- mirage-ci \
     --test-mirage-4
 ```
 
+## Deploying
+
+On ci.mirage.io, the git service is already set up. Otherwise the docker-compose.yml file can be used (might be outdated).
+
+```
+$ git clone -b live https://github.com/ocurrent/mirage-ci.git
+$ cd mirage-ci
+$ docker build . -t mirage-ci
+$ docker service create \
+  --name infra_mirage-ci \
+  -p 8082:8080 \
+  -e CI_PROFILE=production \
+  --mount type=bind,ro,source=/home/camel/.ssh,destination=/ssh \
+  --mount type=bind,ro,source=/home/camel/mirage-ci/cap,destination=/cap \
+  --mount type=bind,source=/var/run/docker.sock,destination=/var/run/docker.sock \
+  --mount type=volume,source=mirage-ci,destination=/var/lib/ocurrent \
+  mirage-ci \
+  --ocluster-cap /cap/mirage-ci.cap \
+  --github-token-file /cap/github_mirage \
+  --git-ssh-host ci.mirage.io \
+  --git-ssh-repo mirage-ci/mirage-monorepo.git \
+  --git-ssh-port 10022 \
+  --git-http-remote=https://ci.mirage.io/git/mirage-ci/mirage-ci-monorepo.git \
+  --privkey /ssh/git \
+  --pubkey /ssh/git.pub \
+  --test-mirage-4 mirage,skeleton,dev \
+  --test-mirage-3 mirage,skeleton,dev \
+  --test-monorepos \
+  --self-deploy
+```
+
 ## Local testing
 
 Without any token, it's possible to test the main pipeline.

--- a/src/dune
+++ b/src/dune
@@ -4,14 +4,42 @@
  (public_name mirage-ci)
  (name mirage_ci)
  (modules mirage_ci logging)
- (libraries common monorepo_lib mirage_ci_pipelines duration capnp-rpc-unix
-   current current.cache current_git current_github current_web
-   current_ocluster routes cmdliner fmt.tty logs.fmt lwt lwt.unix))
+ (libraries
+  common
+  monorepo_lib
+  mirage_ci_pipelines
+  duration
+  capnp-rpc-unix
+  current
+  current.cache
+  current_git
+  current_github
+  current_web
+  current_ocluster
+  routes
+  cmdliner
+  fmt.tty
+  logs.fmt
+  lwt
+  lwt.unix
+  current_docker))
 
 (executable
  (public_name mirage-ci-local)
  (name mirage_ci_local)
  (modules mirage_ci_local logging_local)
- (libraries common mirage_ci_pipelines duration current current.cache
-   current_git current_github current_web astring cmdliner fmt.tty logs.fmt
-   lwt lwt.unix))
+ (libraries
+  common
+  mirage_ci_pipelines
+  duration
+  current
+  current.cache
+  current_git
+  current_github
+  current_web
+  astring
+  cmdliner
+  fmt.tty
+  logs.fmt
+  lwt
+  lwt.unix))

--- a/src/dune
+++ b/src/dune
@@ -4,42 +4,15 @@
  (public_name mirage-ci)
  (name mirage_ci)
  (modules mirage_ci logging)
- (libraries
-  common
-  monorepo_lib
-  mirage_ci_pipelines
-  duration
-  capnp-rpc-unix
-  current
-  current.cache
-  current_git
-  current_github
-  current_web
-  current_ocluster
-  routes
-  cmdliner
-  fmt.tty
-  logs.fmt
-  lwt
-  lwt.unix
-  current_docker))
+ (libraries common monorepo_lib mirage_ci_pipelines duration capnp-rpc-unix
+   current current.cache current_git current_github current_web
+   current_ocluster routes cmdliner fmt.tty logs.fmt lwt lwt.unix
+   current_docker))
 
 (executable
  (public_name mirage-ci-local)
  (name mirage_ci_local)
  (modules mirage_ci_local logging_local)
- (libraries
-  common
-  mirage_ci_pipelines
-  duration
-  current
-  current.cache
-  current_git
-  current_github
-  current_web
-  astring
-  cmdliner
-  fmt.tty
-  logs.fmt
-  lwt
-  lwt.unix))
+ (libraries common mirage_ci_pipelines duration current current.cache
+   current_git current_github current_web astring cmdliner fmt.tty logs.fmt
+   lwt lwt.unix))

--- a/src/mirage_ci.ml
+++ b/src/mirage_ci.ml
@@ -130,8 +130,10 @@ let main current_config github mode auth store config
   let self_deploy =
     if self_deploy then
       let commit =
-        Current_git.clone ~schedule:daily ~gref:"live"
-          "https://github.com/ocurrent/mirage-ci"
+        Github.Api.Anonymous.head_of
+          { Github.Repo_id.owner = "ocurrent"; name = "mirage-ci" }
+          (`Ref "refs/heads/live")
+        |> Current_git.fetch
       in
       let image = Docker.build ~pull:false (`Git commit) in
       [ ("self-deploy", Docker.service ~name:"infra_mirage-ci" ~image ()) ]

--- a/src/mirage_ci.ml
+++ b/src/mirage_ci.ml
@@ -2,6 +2,7 @@ open Monorepo_lib
 open Common
 module Github = Current_github
 module Git = Current_git
+module Docker = Current_docker.Default
 
 let () = Logging.init ()
 let daily = Current_cache.Schedule.v ~valid_for:(Duration.of_day 1) ()
@@ -28,7 +29,8 @@ let gh_head_of github name ref =
       |> Current.map Current_github.Api.Commit.id
 
 let main current_config github mode auth store config
-    (`Test_monorepos monorepos) (`Pipelines_options mirage_pipelines_options) =
+    (`Test_monorepos monorepos) (`Pipelines_options mirage_pipelines_options)
+    (`Self_deploy self_deploy) =
   let config =
     Common.Config.make ~secrets:(Git_store.Cluster.secrets store) config
   in
@@ -125,9 +127,21 @@ let main current_config github mode auth store config
           Mirage_ci_pipelines.PR.routes prs )
   in
 
+  let self_deploy =
+    if self_deploy then
+      let commit =
+        Current_git.clone ~schedule:daily ~gref:"live"
+          "https://github.com/ocurrent/mirage-ci"
+      in
+      let image = Docker.build ~pull:false (`Git commit) in
+      [ ("self-deploy", Docker.service ~name:"infra_mirage-ci" ~image ()) ]
+    else []
+  in
+
   let engine =
     Current.Engine.create ~config:current_config (fun () ->
-        Current.all_labelled (("monorepos", monorepos) :: main_ci))
+        Current.all_labelled
+          ((("monorepos", monorepos) :: main_ci) @ self_deploy))
   in
   let has_role = if auth = None then Current_web.Site.allow_all else has_role in
   let site =
@@ -181,6 +195,16 @@ let github_config =
        (Option.map (fun x ->
             Current_github.Api.of_oauth @@ String.trim (read_file x)))
 
+let self_deploy =
+  Arg.value
+  @@ Arg.flag
+  @@ Arg.info
+       ~doc:
+         "Self deploy https://github.com/ocurrent/mirage-ci to infra_mirage-ci \
+          service"
+       [ "self-deploy" ]
+  |> named (fun x -> `Self_deploy x)
+
 let cmd =
   let doc = "an OCurrent pipeline" in
   ( Term.(
@@ -192,7 +216,8 @@ let cmd =
       $ Git_store.cmdliner
       $ Common.Config.cmdliner
       $ test_monorepos
-      $ main_ci),
+      $ main_ci
+      $ self_deploy),
     Term.info program_name ~doc )
 
 let () = Term.(exit @@ eval cmd)


### PR DESCRIPTION
This integrates a small pipeline to watch track the `live` branch of https://github.com/ocurrent/mirage-ci and update the docker service