### PR TITLE
Bump min version of ocaml and fix deprecations

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,6 +1,6 @@
-version = 0.20.1
+version = 0.21.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true
 module-item-spacing = compact
-ocaml-version = 4.08.0
+ocaml-version = 4.10.0

--- a/dune-project
+++ b/dune-project
@@ -47,4 +47,4 @@
   capnp-rpc-unix
   opam-format
   git-unix
-  (ocaml (>= 4.08.0))))
+  (ocaml (>= 4.10.0))))

--- a/mirage-ci.opam
+++ b/mirage-ci.opam
@@ -46,7 +46,7 @@ depends: [
   "capnp-rpc-unix"
   "opam-format"
   "git-unix"
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.10.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/mirage_ci_local.ml
+++ b/src/mirage_ci_local.ml
@@ -69,12 +69,15 @@ let main_ci =
 
 let cmd =
   let doc = "an OCurrent pipeline" in
-  ( Term.(
+  let term =
+    Term.(
       const main
       $ Current.Config.cmdliner
       $ Current_web.cmdliner
       $ Common.Config.cmdliner
-      $ main_ci),
-    Term.info program_name ~doc )
+      $ main_ci)
+  in
+  let info = Cmd.info program_name ~doc in
+  Cmd.v info (Term.term_result term)
 
-let () = Term.(exit @@ eval cmd)
+let () = exit @@ Cmd.eval cmd

--- a/src/website/website.ml
+++ b/src/website/website.ml
@@ -130,11 +130,14 @@ module Website_description = struct
             Fmt.str "PR #%d: %s" id title
         | `Github { ref = `Ref ref; _ } -> Fmt.str "Branch %s" (branch_name ref)
 
-      let compare a b = match a, b with
-        | `Github { ref = `Ref ref_a; _ }, `Github { ref = `Ref ref_b; _ } -> String.compare ref_a ref_b
-        | `Github { ref = `PR {id=id_a; _}; _ }, `Github { ref = `PR {id=id_b; _}; _ } -> id_b - id_a
+      let compare a b =
+        match (a, b) with
+        | `Github { ref = `Ref ref_a; _ }, `Github { ref = `Ref ref_b; _ } ->
+            String.compare ref_a ref_b
+        | ( `Github { ref = `PR { id = id_a; _ }; _ },
+            `Github { ref = `PR { id = id_b; _ }; _ } ) ->
+            id_b - id_a
         | a, b -> String.compare (to_string a) (to_string b)
-      
     end
 
     type t = Source.t


### PR DESCRIPTION
We're bumping the min version of ocaml on `current-web-pipelines` and so doing similar here.

Taking the opportunity to fix cmdliner errors and taking ocamlformat's formatting suggestions.