### PR TITLE
Install docker-buildx-plugin to restore self-update functionality.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM debian:11
 RUN apt-get update && apt-get install libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase gzip bzip2 xz-utils unzip tar -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
-RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
+RUN apt-get update && apt-get install docker-ce docker-buildx-plugin -y --no-install-recommends
 RUN git config --global user.name "mirage" && git config --global user.email "ci"
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/mirage-ci"]


### PR DESCRIPTION
Related to https://github.com/ocurrent/ocaml-ci/pull/759 
Fixes https://github.com/ocurrent/mirage-ci/issues/28