### PR TITLE
Adopt the OCaml Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
+
+To report any violations, please contact:
+
+* Alpha Diallo <alpha [at] tarides [dot] com>
+* Tim McGilchrist <timmcgil [at] gmail [dot] com>
+* Riku Silvola <riku [at] tarides [dot] com>


### PR DESCRIPTION
The OCaml Code of Conduct can be found in [ocaml/code-of-conduct](https://github.com/ocaml/code-of-conduct) and has been discussed [in this Discourse thread](https://discuss.ocaml.org/t/ocaml-community-code-of-conduct/10494).

We propose adopting it for ocurrent/mirage-ci as well.

cc @moyodiallo @tmcgilchrist