### PR TITLE
Update to upstream changes in current-web-pipelines

### DIFF
--- a/src/mirage_ci.ml
+++ b/src/mirage_ci.ml
@@ -53,6 +53,11 @@ let main current_config github mode auth config
     | Some prs ->
         let current = Current_web_pipelines.Task.current prs in
         let state =
+          let state_active =
+            Current_web_pipelines.Task.state prs
+            |> Current.map (List.map (fun v -> v.Current_web_pipelines.State.metadata) )
+            |> Website.set_active_sources website
+          in
           let input = Current_web_pipelines.Task.state prs in
           Current.list_iter ~collapse_key:"update-web-state"
             (module struct
@@ -65,6 +70,7 @@ let main current_config github mode auth config
             end)
             (Website.update_state website)
             input
+          |> Current.pair state_active |> Current.map ignore
           |> Current.collapse ~key:"current-web-pipeline-internals" ~value:""
                ~input:
                  (Current.return ~label:"current-web-pipelines internals" ())

--- a/src/mirage_ci_local.ml
+++ b/src/mirage_ci_local.ml
@@ -29,6 +29,11 @@ let main current_config mode config
     Current.Engine.create ~config:current_config (fun () ->
         let current = Current_web_pipelines.Task.current main_ci in
         let state =
+          let state_active =
+            Current_web_pipelines.Task.state main_ci
+            |> Current.map (List.map (fun v -> v.Current_web_pipelines.State.metadata) )
+            |> Website.set_active_sources website
+          in
           Current.list_iter ~collapse_key:"update-web-state"
             (module struct
               type t = Website.pipeline_state
@@ -40,6 +45,7 @@ let main current_config mode config
             end)
             (Website.update_state website)
             (Current_web_pipelines.Task.state main_ci)
+          |> Current.pair state_active |> Current.map ignore
         in
         [ ("mirage-main-ci", current); ("mirage-state", state) ]
         |> Current.all_labelled)


### PR DESCRIPTION
In preparation for the release (https://github.com/ocaml/opam-repository/pull/24062).
This PR can be merged as it is. Once the package is released, vendoring can also be removed.

Basically current-web-pipelines now requires to know which runs are still active (i.e. tracked by ocurrent) to display the inactive ones separately.