### PR TITLE
let's use mirageos.org instead of mirage.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ tested together.
 
 The opam-repository commit used to test the applications is updated *once a day*.
 It's possible to manually ask the CI to update the commit:
-- go to the pipeline page: https://ci.mirage.io/?repo=mirage/mirage-skeleton&
+- go to the pipeline page: https://ci.mirageos.org/?repo=mirage/mirage-skeleton&
 - click on the `clone https://github.com/ocaml/opam-repository master` box
 - click on `Rebuild`
 
@@ -58,9 +58,9 @@ dune exec -- mirage-ci \
 ## Deploying
 
 The `live` branch will automatically be deployed to
-[ci.mirage.io](https://ci.mirage.io/).
+[ci.mirageos.org](https://ci.mirageos.org/).
 
-To (re)-configure the live-deployer, log on `ci.mirage.io` and run:
+To (re)-configure the live-deployer, log on `ci.mirageos.org` and run:
 
 ```
 $ git clone -b live https://github.com/ocurrent/mirage-ci.git
@@ -77,10 +77,10 @@ $ docker service create \
   mirage-ci \
   --ocluster-cap /cap/mirage-ci.cap \
   --github-token-file /cap/github_mirage \
-  --git-ssh-host ci.mirage.io \
+  --git-ssh-host ci.mirageos.org \
   --git-ssh-repo mirage-ci/mirage-monorepo.git \
   --git-ssh-port 10022 \
-  --git-http-remote=https://ci.mirage.io/git/mirage-ci/mirage-ci-monorepo.git \
+  --git-http-remote=https://ci.mirageos.org/git/mirage-ci/mirage-ci-monorepo.git \
   --privkey /ssh/git \
   --pubkey /ssh/git.pub \
   --test-mirage-4 mirage,skeleton,dev,overlay \

--- a/src/lib/monorepo/monorepo_git_push.ml
+++ b/src/lib/monorepo/monorepo_git_push.ml
@@ -109,7 +109,7 @@ module GitPush = struct
           "-m";
           "monorepo-git-push";
           "--author";
-          "Mirage CI pipeline <ci@mirage.io>";
+          "Mirage CI pipeline <ci@mirageos.org>";
         |]
     in
     let** () =

--- a/src/pipelines/PR.ml
+++ b/src/pipelines/PR.ml
@@ -62,7 +62,7 @@ type t =
 
 let gh_url (meta, stage) =
   Uri.of_string
-    (Fmt.str "https://ci.mirage.io%s"
+    (Fmt.str "https://ci.mirageos.org%s"
        (Website.pipeline_stage_url (`Github meta) stage))
 
 let github_status_of_state meta status =


### PR DESCRIPTION
I don't know whether this needs additional changes.

From the DNS perspective, both ci.mirageos.org and deploy.mirageos.org are pointing to the same host as {ci,deploy}.mirage.io.