### PR TITLE
4.14.3 -> 4.14.4

### DIFF
--- a/src/lib/common/platform.ml
+++ b/src/lib/common/platform.ml
@@ -3,7 +3,7 @@ type ocaml_version = V4_14 | V5_4
 let pp_ocaml f = function V4_14 -> Fmt.pf f "4.14" | V5_4 -> Fmt.pf f "5.4"
 
 let pp_exact_ocaml f = function
-  | V4_14 -> Fmt.pf f "4.14.3"
+  | V4_14 -> Fmt.pf f "4.14.4"
   | V5_4 -> Fmt.pf f "5.4.1"
 
 type os = Debian | Ubuntu | Fedora


### PR DESCRIPTION
Meanwhile 4.14.4 got released.

See https://github.com/ocurrent/mirage-ci/pull/56

The docker container would use the latest minor version, but the solver wants to know the exact version. Depending on the OCaml CI's backlog it'd run jobs at different times, which results in a situation where some CI jobs pass, and others fail if a new compiler minor version got released inbetween.

For now bump 4.14 to match the container.