### PR TITLE
Refresh base images via per-arch digests on a schedule

### DIFF
--- a/src/lib/common/platform.ml
+++ b/src/lib/common/platform.ml
@@ -28,6 +28,8 @@ let spec t = Spec.make @@ Fmt.str "ocaml/opam:%a" pp_system t
 
 type t = { system : system; arch : arch }
 
+let docker_arch = function Arm64 -> "arm64" | Amd64 -> "amd64"
+
 let platform_id t =
   match t.arch with
   | Arm64 -> "arm64-" ^ Fmt.str "%a" pp_system t.system
@@ -39,6 +41,26 @@ let pp_platform f t =
 
 let ocluster_pool { arch; _ } =
   match arch with Arm64 -> "linux-arm64" | Amd64 -> "linux-x86_64"
+
+(* The [ocaml/opam:<distro>-ocaml-<v>] tag is a floating multi-arch tag that
+   upstream rebuilds (e.g. when a new patch release of OCaml lands). obuilder
+   caches a fetched base image by the literal [from] string, so referencing the
+   floating tag directly means a worker never picks up a rebuild. Instead we
+   periodically re-resolve the tag to a concrete per-arch digest via
+   [docker manifest inspect] and feed that into the spec: when the digest moves,
+   obuilder's cache key changes and the worker re-fetches. Mirrors ocaml-ci,
+   including its 30-day cadence: upstream only rebuilds these base images
+   occasionally, so re-resolving more often just burns build cycles. *)
+let base_image_schedule =
+  Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) ()
+
+let pull_base t =
+  let open Current.Syntax in
+  let tag = Fmt.str "ocaml/opam:%a" pp_system t.system in
+  Current.component "pull@,%a" pp_platform t
+  |> let> () = Current.return () in
+     Current_docker.Raw.peek ~docker_context:None
+       ~schedule:base_image_schedule ~arch:(docker_arch t.arch) tag
 
 (* Base configuration.. *)
 

--- a/src/lib/monorepo/monorepo.ml
+++ b/src/lib/monorepo/monorepo.ml
@@ -12,16 +12,16 @@ let v ~system ~repos =
   let+ solver = Current_solver.v ~system ~repos ~packages:[ "opam-monorepo" ] in
   { solver }
 
-let lock_spec ~system ~repos ~opam =
+let lock_spec ~base ~repos ~opam =
   let open Obuilder_spec in
   let opam_monorepo =
-    Platform.spec system
+    Spec.make base
     |> Spec.add (Setup.add_repositories repos)
     |> Spec.add (Setup.install_tools [ "opam-monorepo" ])
     |> Spec.add [ run "sudo cp $(opam var bin)/opam-monorepo /opam-monorepo" ]
     |> Spec.finish
   in
-  Platform.spec system
+  Spec.make base
   |> Spec.add (Setup.add_repositories repos)
   |> Spec.children ~name:"monorepo" opam_monorepo
   |> Spec.add
@@ -77,8 +77,10 @@ end
 
 let lock ~key ~config ~store ~repos ~opam ~system =
   let spec =
-    let+ opam = opam and+ repos = repos in
-    lock_spec ~system ~repos ~opam |> upload_spec ~store ~branch:key
+    let+ opam = opam
+    and+ repos = repos
+    and+ base = Platform.pull_base { system; arch = Platform.Amd64 } in
+    lock_spec ~base ~repos ~opam |> upload_spec ~store ~branch:key
   in
   let job = Common.Config.build config ~pool:"linux-x86_64" ~src:[] spec in
   let k =

--- a/src/pipelines/monorepo.ml
+++ b/src/pipelines/monorepo.ml
@@ -35,11 +35,11 @@ let get_monorepo_library ~mirage_only =
   |}
     (Fmt.list pp_project)
 
-let spec ~mode ~repos ~system ~toolchain ~lock =
+let spec ~mode ~repos ~base_image ~toolchain ~lock =
   let open Obuilder_spec in
   let base =
-    let+ repos = repos in
-    Platform.spec system |> Spec.add (Setup.add_repositories repos)
+    let+ repos = repos and+ base_image = base_image in
+    Spec.make base_image |> Spec.add (Setup.add_repositories repos)
   in
   let base =
     let+ base = base in
@@ -84,7 +84,8 @@ let spec ~mode ~repos ~system ~toolchain ~lock =
 
 let v ~config ~(platform : Platform.t) ~roots ~mode ?(src = [])
     ?(toolchain = Host) ~repos ~lock () =
-  let spec = spec ~system:platform.system ~mode ~repos ~toolchain ~lock in
+  let base_image = Platform.pull_base platform in
+  let spec = spec ~base_image ~mode ~repos ~toolchain ~lock in
   let mirage_only = match toolchain with Host -> false | _ -> true in
   let dune_build =
     let+ spec = spec in

--- a/src/pipelines/skeleton.ml
+++ b/src/pipelines/skeleton.ml
@@ -51,13 +51,14 @@ let make_instructions =
         ]
 
 (* Test all of mirage-skeleton at once *)
-let all_in_one_test ~(platform : Platform.t) ~target ~repos ~mirage ~config
+let all_in_one_test ~(platform : Platform.t) ~target ~base ~repos ~mirage ~config
     ~build_mode mirage_skeleton =
   let mirage_cmd = match build_mode with Mirage_4 _ -> "\"mirage>=4\"" in
   let spec =
     let+ repos = repos
     and+ make_instructions = make_instructions build_mode
-    and+ mirage = Current.option_seq mirage in
+    and+ mirage = Current.option_seq mirage
+    and+ base = base in
 
     let open Obuilder_spec in
     let pin_mirage =
@@ -68,7 +69,7 @@ let all_in_one_test ~(platform : Platform.t) ~target ~repos ~mirage ~config
           ]
       | None, _ -> []
     in
-    Platform.spec platform.system
+    Spec.make base
     |> Spec.add (Setup.add_repositories repos)
     |> Spec.add pin_mirage
     |> Spec.add (Setup.install_tools [ mirage_cmd ])
@@ -88,11 +89,15 @@ let all_in_one_test ~(platform : Platform.t) ~target ~repos ~mirage ~config
 
 let all_in_one_test ~(platform : Platform.t) ~repos ~mirage ~config ~build_mode
     mirage_skeleton =
+  (* Resolve the base image once per platform and share the result across all
+     targets, so the DAG shows a single "pull" node per platform rather than one
+     per build. *)
+  let base = Platform.pull_base platform in
   targets
   |> List.filter (is_available_on platform)
   |> List.map (fun target ->
-         all_in_one_test ~target ~platform ~repos ~mirage ~config ~build_mode
-           mirage_skeleton)
+         all_in_one_test ~target ~platform ~base ~repos ~mirage ~config
+           ~build_mode mirage_skeleton)
   |> Current_web_pipelines.Task.all
   |> Current_web_pipelines.Task.map_state (fun jobs ->
          {


### PR DESCRIPTION
Builds referenced the floating `ocaml/opam:<distro>-ocaml-<version>` tag in the obuilder `from`. obuilder caches the base by the literal `from` string, so workers never pick up upstream rebuilds and arches can diverge — when 5.4.0→5.4.1 landed, x86_64 used 5.4.1 while arm64 kept its cached 5.4.0.

Mirror ocaml-ci: re-resolve the tag to a per-arch digest via `docker manifest inspect` (`Current_docker.Raw.peek`) on a 30-day schedule and use that as the base. When the tag is rebuilt the digest moves, the cache key changes, and workers re-fetch. Resolved once per platform and shared, so the DAG shows one `pull` node per image.